### PR TITLE
Don't read whole makeself archive into memory

### DIFF
--- a/makeself_safeextract.py
+++ b/makeself_safeextract.py
@@ -11,6 +11,11 @@ from __future__ import (absolute_import, division, print_function,
                         with_statement, unicode_literals)
 
 __author__ = "Stephan Sokolow (deitarion/SSokolow)"
+__authors__ = [
+    "Stephan Sokolow (deitarion/SSokolow)",
+    "Thiago Jung Bauermann",
+]
+__author__ = ', '.join(__authors__)
 __appname__ = "[application name here]"
 __version__ = "0.0pre0"
 __license__ = "GNU GPL 3.0 or later"


### PR DESCRIPTION
Hello  Stephan Sokolow,

I made this improvement to your script. I hope you can consider merging it:

Some makeself archives are very big (e.g., game installers can be 4 GB or more). It's very taxing on the machine to read the whole data hunk into memory before writing it to a separate file.

Therefore, this pull request changes the logic to read and write each data hunk 1 MB at a time. This makes the script a lot lighter in terms of memory usage, and extracting a 4 GB makeself archive becomes feasible on my machine, which has 6 GB of RAM.

There are two commits: the first one is just a cleanup step to make the main change simpler. It doesn't change the behavior of the script in any way.

I tested with a couple of GOG installers, and the script worked correctly on both of them. I tested with and without the `--mojo` option.